### PR TITLE
Update unpooling_layer.cpp

### DIFF
--- a/src/caffe/layers/unpooling_layer.cpp
+++ b/src/caffe/layers/unpooling_layer.cpp
@@ -98,8 +98,8 @@ void UnpoolingLayer<Dtype>::Reshape(const vector<Blob<Dtype>*>& bottom,
     kernel_h_ = bottom[0]->height();
     kernel_w_ = bottom[0]->width();
   }
-  unpooled_height_ = static_cast<int>((height_ - 1) * stride_h_ + kernel_h_ - 2 * pad_h_);
-  unpooled_width_ = static_cast<int>((width_ - 1) * stride_w_ + kernel_w_ - 2 * pad_w_);
+  unpooled_height_ = static_cast<int>((height_ - 1) * stride_h_ + kernel_h_ - 2 * pad_h_) - ((height_ % 2 == 0) ? 1 : 0);
+  unpooled_width_ = static_cast<int>((width_ - 1) * stride_w_ + kernel_w_ - 2 * pad_w_) - ((width_ % 2 == 0) ? 1 : 0);
   top[0]->Reshape(bottom[0]->num(), channels_, unpooled_height_,
       unpooled_width_);
 }


### PR DESCRIPTION
New edits take into account reversing Pooling ceil() function when it actually 'rounds up' a value.